### PR TITLE
Fix bug in ByteIterator

### DIFF
--- a/src/main/java/com/spotify/sshagentproxy/ByteIterator.java
+++ b/src/main/java/com/spotify/sshagentproxy/ByteIterator.java
@@ -58,7 +58,7 @@ class ByteIterator implements Iterator<byte[]> {
   private int s2i(final byte[] bytes) {
     int num = 0;
     for (int i = 0; i < 4; i++) {
-      num += (int) bytes[i] << ((3 - i) * 8);
+      num += (bytes[i] & 0xff) << ((3 - i) * 8);
     }
     return num;
   }

--- a/src/test/java/com/spotify/sshagentproxy/ByteIteratorTest.java
+++ b/src/test/java/com/spotify/sshagentproxy/ByteIteratorTest.java
@@ -18,7 +18,9 @@ package com.spotify.sshagentproxy;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
@@ -35,4 +37,18 @@ public class ByteIteratorTest {
     assertFalse(iterator.hasNext());
   }
 
+  @Test
+  public void testTurnByteIntoUnsignedInt() {
+    // Test that signed bytes using 2's complement are turned into unsigned ints
+    byte[] bytes = new byte[437];
+    new Random().nextBytes(bytes);
+    bytes[0] = 0;
+    bytes[1] = 0;
+    bytes[2] = 1;
+    bytes[3] = -79;
+
+    final Iterator<byte[]> iterator = new ByteIterator(bytes);
+    assertThat(iterator.next(), equalTo(Arrays.copyOfRange(bytes, 4, bytes.length)));
+    assertFalse(iterator.hasNext());
+  }
 }


### PR DESCRIPTION
Convert signed bytes in 2's complement form to unsigned ints.
Otherwise, we could get negative numbers that are supposed
to represent how many bytes to read from the ssh-agent.
