### PR TITLE
forgot a parenthesis in 38e8d04

### DIFF
--- a/src/main/java/com/spotify/sshagentproxy/IdentitiesAnswerHeaders.java
+++ b/src/main/java/com/spotify/sshagentproxy/IdentitiesAnswerHeaders.java
@@ -70,7 +70,7 @@ class IdentitiesAnswerHeaders extends AgentReplyHeaders {
     if (responseCode != SSH2_AGENT_IDENTITIES_ANSWER) {
       throw new RuntimeException("Got the wrong response code for SSH2_AGENT_IDENTITIES_ANSWER"
                                  + " (expected: " + SSH2_AGENT_IDENTITIES_ANSWER
-                                 + ", received: " + responseCode + ".");
+                                 + ", received: " + responseCode + ").");
     }
 
     // Next four bytes is the number of keys the agent has


### PR DESCRIPTION
leads to ugly error messages like 

> Got the wrong response code for SSH2_AGENT_IDENTITIES_ANSWER (expected: 12, received: 0.