### PR TITLE
bump jnr-unixsocket to support aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.18</version>
+      <version>0.38.17</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
Needed for helios client to work on Apple M1 laptops. The current version of the library makes the `helios` client fail with `java.lang.UnsatisfiedLinkError: could not load FFI provider jnr.ffi.provider.jffi.Provider`